### PR TITLE
Utilizar o tema do sistema

### DIFF
--- a/.obsidian/appearance.json
+++ b/.obsidian/appearance.json
@@ -1,6 +1,6 @@
 {
   "cssTheme": "Minimal",
-  "theme": "moonstone",
+  "theme": "system",
   "accentColor": "#00aeef",
   "showViewHeader": true,
   "interfaceFontFamily": "Arial",

--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -61,7 +61,7 @@
                 "sortOrder": "alphabetical"
               },
               "icon": "lucide-folder-closed",
-              "title": "File explorer"
+              "title": "Files"
             }
           },
           {
@@ -162,8 +162,7 @@
     "hiddenItems": {
       "switcher:Open quick switcher": false,
       "command-palette:Open command palette": false,
-      "zk-prefixer:Create new unique note": false,
-      "table-editor-obsidian:Advanced Tables Toolbar": false
+      "zk-prefixer:Create new unique note": false
     }
   },
   "active": "6d159acde19cab90",


### PR DESCRIPTION
Define que o Obsidian deverá utilizar o tema definido pelo utilizador no OS por omissão, em vez do modo claro.